### PR TITLE
Removed reference to Android Developer as the link is not valid

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,6 @@ This specialty is based on [Google's "Project Management" career certificate](ht
 
 This specialty is based on [Google's "Data Analytics" career certificate](https://grow.google/dataanalytics/).
 
-## Android Developer
-
-This specialty is based on [Google's "Android Development" career certificate](https://grow.google/androiddev/).
-
 ---
 
 All Google's career certificates: https://grow.google/certificates/


### PR DESCRIPTION
Removed reference to Android Developer as the link (https://grow.google/certificates/android-developer/) provided is no longer valid

Attaching the error page screenshot for reference 

<img width="796" alt="Error Page screenshot" src="https://user-images.githubusercontent.com/115688738/198548352-e69157d0-f518-40dc-aca3-f6ec6667a531.png">
<img width="796" alt="Error Page screenshot" src="https://user-images.githubusercontent.com/115688738/198548388-adf9b59b-ce1b-47d2-8673-7236ee7d7cf2.png">
